### PR TITLE
add: shuffle-chain

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,87 +1,23 @@
-
-var app = new Vue({ 
+var app = new Vue({
     el: '#app',
-    data: {
-        runSchemeResult: '(runSchemeResult)',
-        message: '(nothing selected)',
-        selectedItem: Object, 
-        scheme: {
-            id: 'Main',
-            type: 'row',
-            childs: [
-                {
-                    id: 'D',
-                    type: 'column',
-                    childs: [
-                        {
-                            id: 'A',
-                            type: 'row',
-                            childs: [
-                                {
-                                    id:'A1',
-                                    type:'filter',
-                                    result: false,
-                                },
-                                {
-                                    id:'A2',
-                                    type:'filter',
-                                    result: true,
-                                },
-                            ],
-                        },
-                        {
-                            id:'B',
-                            type:'column',
-                            childs:[
-                                {
-                                    id:'B1',
-                                    type:'filter',
-                                    result: true,
-                                },
-                                {
-                                    id:'B2',
-                                    type:'filter',
-                                    result: false,
-                                },
-                            ],
-                        },
-                    ],
-                },
-                {
-                    id: 'C1',
-                    type: 'filter',
-                    result: true,
-                },
-                {
-                    id: 'Z',
-                    type: 'column',
-                    childs: [
-                        {
-                            id: 'Z1',
-                            type: 'filter',
-                            result: false,
-                        },
-                        {
-                            id: 'Z2',
-                            type: 'filter',
-                            result: true,
-                        },
-                    ],
-                },
-            ],
-        },
+    data() {
+        return {
+            runSchemeResult: '(runSchemeResult)',
+            message: '(nothing selected)',
+            selectedItem: Object,
+            scheme: MainChain,
+            secondScheme: SecondChain
+        };
     },
     methods: {
-        onFocus: function() {
-            this.selectElementById(this.id);
+        onFocus: function () {
+            this.selectedItem = {}
         },
-        selectElementById: function(id)  {
-            var item = searchInSchemeById(this.scheme, id);
+        onSelectedChange(item) {
             this.selectedItem = item;
         },
-        getSchemeResult: function(scheme) {
+        getSchemeResult: function (scheme) {
             return runScheme(scheme);
         }
-      }
+    },
 });
-

--- a/app.js
+++ b/app.js
@@ -6,111 +6,24 @@ var app = new Vue({
         message: '(nothing selected)',
         selectedScheme: {},
         selectedItem: {},
-        scheme: {
-            id: 'Main',
-            type: 'row',
-            childs: [
-                {
-                    id: 'D',
-                    type: 'column',
-                    childs: [
-                        {
-                            id: 'A',
-                            type: 'row',
-                            childs: [
-                                {
-                                    id: 'A1',
-                                    type: 'filter',
-                                    result: false,
-                                    params: [
-                                        {
-                                            name: 'Alpha',
-                                            type: 'set',
-                                            source: 'inline',
-                                            value: ['cafe', 'kids', 'beach'],
-                                        },
-                                        {
-                                            name: 'Beta',
-                                            type: 'set',
-                                            source: 'local',
-                                            key: "ballooning-fest",
-                                        }
-                                    ]
-                                },
-                                {
-                                    id: 'A2',
-                                    type: 'filter',
-                                    result: true,
-                                    params: [
-                                        {
-                                            name: 'User',
-                                            type: 'set',
-                                            source: 'incoming',
-                                            key: 'user',
-                                        },
-                                        {
-                                            name: 'Cafe',
-                                            type: 'set',
-                                            source: 'incoming',
-                                            key: 'place',
-                                        }
-                                    ]
-                                },
-                            ],
-                        },
-                        {
-                            id: 'B',
-                            type: 'column',
-                            childs: [
-                                {
-                                    id: 'B1',
-                                    type: 'filter',
-                                    result: true,
-                                },
-                                {
-                                    id: 'B2',
-                                    type: 'filter',
-                                    result: false,
-                                },
-                            ],
-                        },
-                    ],
-                },
-                {
-                    id: 'C1',
-                    type: 'filter',
-                    result: true,
-                },
-                {
-                    id: 'Z',
-                    type: 'column',
-                    childs: [
-                        {
-                            id: 'Z1',
-                            type: 'filter',
-                            result: false,
-                        },
-                        {
-                            id: 'Z2',
-                            type: 'filter',
-                            result: true,
-                        },
-                    ],
-                },
-            ],
-        },
         local: {
-            'ballooning-fest': ['sunday', 'beach'],
+            'ballooning-fest': ['sunday', 'beach', 'family'],
             'hollydays': ['sunday', 'saturday'],
         },
         incoming: {
-            'user': ['cafe', 'kids'],
+            'user': ['cafe', 'kids', 'family'],
             'place': ['cafe', 'coffe', 'tea', 'chicken', 'pizza', 'latte', 'free-hot-water'],
         },
     },
     computed: {
         varsOfSchemes() {
             return chains || []
+        },
+        serializedLocal() {
+            return JSON.stringify(this.local || {})
+        },
+        serializedIncoming() {
+            return JSON.stringify(this.incoming || {})
         }
     },
     methods: {

--- a/app.js
+++ b/app.js
@@ -15,9 +15,6 @@ var app = new Vue({
         },
         onSelectedChange(item) {
             this.selectedItem = item;
-        },
-        getSchemeResult: function (scheme) {
-            return runScheme(scheme);
         }
     },
 });

--- a/app.js
+++ b/app.js
@@ -4,16 +4,17 @@ var app = new Vue({
         return {
             runSchemeResult: '(runSchemeResult)',
             message: '(nothing selected)',
-            selectedItem: Object,
-            scheme: MainChain,
-            secondScheme: SecondChain
+            selectedScheme: {},
+            selectedItem: {},
         };
     },
-    methods: {
-        onFocus: function () {
-            this.selectedItem = {}
+    computed: {
+        varsOfSchemes() {
+            return chains || []
         },
-        onSelectedChange(item) {
+    },
+    methods: {
+        onSelectItem(item) {
             this.selectedItem = item;
         }
     },

--- a/app.js
+++ b/app.js
@@ -1,17 +1,116 @@
 var app = new Vue({
     el: '#app',
-    data() {
-        return {
-            runSchemeResult: '(runSchemeResult)',
-            message: '(nothing selected)',
-            selectedScheme: {},
-            selectedItem: {},
-        };
+    data:
+    {
+        runSchemeResult: '(runSchemeResult)',
+        message: '(nothing selected)',
+        selectedItem: Object,
+        scheme: {
+            id: 'Main',
+            type: 'row',
+            childs: [
+                {
+                    id: 'D',
+                    type: 'column',
+                    childs: [
+                        {
+                            id: 'A',
+                            type: 'row',
+                            childs: [
+                                {
+                                    id: 'A1',
+                                    type: 'filter',
+                                    result: false,
+                                    params: [
+                                        {
+                                            name: 'Alpha',
+                                            type: 'set',
+                                            source: 'inline',
+                                            value: ['cafe', 'kids'],
+                                        },
+                                        {
+                                            name: 'Beta',
+                                            type: 'set',
+                                            source: 'local',
+                                            key: "ballooning-fest",
+                                        }
+                                    ]
+                                },
+                                {
+                                    id: 'A2',
+                                    type: 'filter',
+                                    result: true,
+                                    params: [
+                                        {
+                                            name: 'User',
+                                            type: 'set',
+                                            source: 'incoming',
+                                            key: 'user',
+                                        },
+                                        {
+                                            name: 'Cafe',
+                                            type: 'set',
+                                            source: 'incoming',
+                                            key: 'place',
+                                        }
+                                    ]
+                                },
+                            ],
+                        },
+                        {
+                            id: 'B',
+                            type: 'column',
+                            childs: [
+                                {
+                                    id: 'B1',
+                                    type: 'filter',
+                                    result: true,
+                                },
+                                {
+                                    id: 'B2',
+                                    type: 'filter',
+                                    result: false,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    id: 'C1',
+                    type: 'filter',
+                    result: true,
+                },
+                {
+                    id: 'Z',
+                    type: 'column',
+                    childs: [
+                        {
+                            id: 'Z1',
+                            type: 'filter',
+                            result: false,
+                        },
+                        {
+                            id: 'Z2',
+                            type: 'filter',
+                            result: true,
+                        },
+                    ],
+                },
+            ],
+        },
+        local: {
+            'ballooning-fest': ['sunday', 'beach'],
+            'hollydays': ['sunday', 'saturday'],
+        },
+        incoming: {
+            'user': ['cafe', 'kids'],
+            'place': ['cafe', 'coffe', 'tea', 'chicken', 'pizza', 'latte', 'free-hot-water'],
+        },
     },
     computed: {
         varsOfSchemes() {
             return chains || []
-        },
+        }
     },
     methods: {
         onSelectItem(item) {

--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ var app = new Vue({
                                             name: 'Alpha',
                                             type: 'set',
                                             source: 'inline',
-                                            value: ['cafe', 'kids'],
+                                            value: ['cafe', 'kids', 'beach'],
                                         },
                                         {
                                             name: 'Beta',

--- a/app.js
+++ b/app.js
@@ -4,7 +4,8 @@ var app = new Vue({
     {
         runSchemeResult: '(runSchemeResult)',
         message: '(nothing selected)',
-        selectedItem: Object,
+        selectedScheme: {},
+        selectedItem: {},
         scheme: {
             id: 'Main',
             type: 'row',

--- a/components/shuffle-chain.js
+++ b/components/shuffle-chain.js
@@ -1,0 +1,35 @@
+Vue.component('shuffle-chain', {
+    props: {
+        schema: {
+            type: Object,
+            required: true,
+        },
+    },
+    data: function () {
+        return {}
+    },
+    methods: {
+        onFocus: function () {
+            var item = this.selectElementById(this.id || this.schema.id);
+            this.$emit("selected-item-changed", item);
+        },
+        onSelectedChange(item) {
+            this.$emit("selected-item-changed", item)
+        },
+        selectElementById(id) {
+            var item = searchInSchemeById(this.schema, id);
+            this.$emit("selected-item-changed", item);
+        },
+        getSchemeResult: function (scheme) {
+            return runScheme(scheme);
+        }
+    },
+    template: `
+    <component :is="schema.type" :id="schema.id">
+        <template v-if="schema.childs">
+            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="schema.id" @focus="onFocus" @selected-item-changed="onSelectedChange" />
+        </template>
+    </component>
+    `,
+});
+

--- a/components/shuffle-chain.js
+++ b/components/shuffle-chain.js
@@ -25,9 +25,9 @@ Vue.component('shuffle-chain', {
         }
     },
     template: `
-    <component :is="schema.type" :id="schema.id">
+    <component :is="schema.type" :id="schema.id" @focus="onFocus">
         <template v-if="schema.childs">
-            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="schema.id" @focus="onFocus" @selected-item-changed="onSelectedChange" />
+            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="schema.id" @selected-item-changed="onSelectedChange" />
         </template>
     </component>
     `,

--- a/components/shuffle-chain.js
+++ b/components/shuffle-chain.js
@@ -5,29 +5,33 @@ Vue.component('shuffle-chain', {
             required: true,
         },
     },
+    emits: ['on-select-item'],
     data: function () {
         return {}
     },
     methods: {
-        onFocus: function () {
-            var item = this.selectElementById(this.id || this.schema.id);
-            this.$emit("selected-item-changed", item);
+        onChildrenSelectItem(item) {
+            if (item) {
+                this.$emit("on-select-item", item)
+            }
         },
-        onSelectedChange(item) {
-            this.$emit("selected-item-changed", item)
+        onSelectById(id) {
+            var item = this.selectElementById(id);
+            if (item) {
+                this.$emit("on-select-item", item)
+            }
         },
         selectElementById(id) {
-            var item = searchInSchemeById(this.schema, id);
-            this.$emit("selected-item-changed", item);
+            return searchInSchemeById(this.$props.schema, id)
         },
         getSchemeResult: function (scheme) {
             return runScheme(scheme);
         }
     },
     template: `
-    <component :is="schema.type" :id="schema.id" @focus="onFocus">
+    <component :is="schema.type" :id="schema.id" @on-select-id="onSelectById">
         <template v-if="schema.childs">
-            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="schema.id" @selected-item-changed="onSelectedChange" />
+            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="schema.id" @on-select-item="onChildrenSelectItem"/>
         </template>
     </component>
     `,

--- a/components/shuffle-chain.js
+++ b/components/shuffle-chain.js
@@ -31,7 +31,7 @@ Vue.component('shuffle-chain', {
     template: `
     <component :is="schema.type" :id="schema.id" @on-select-id="onSelectById">
         <template v-if="schema.childs">
-            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="schema.id" @on-select-item="onChildrenSelectItem"/>
+            <shuffle-chain v-for="child in schema.childs" :key="child.id" :schema="child" :id="child.id" @on-select-item="onChildrenSelectItem"/>
         </template>
     </component>
     `,

--- a/components/shuffle-column.js
+++ b/components/shuffle-column.js
@@ -2,19 +2,10 @@ Vue.component('shuffle-column', {
     data: function () {
         return {}
     },
+    emits: ['on-select-id'],
     methods: {
         onFocus: function () {
-            if (typeof this.selectElementById === 'function') {
-                this.selectElementById(this.id);
-            }
-        },
-        selectElementById(id) {
-            const parent = this.$parent;
-            if (parent && parent?.schema && typeof this.selectElementById === 'function') {
-                this.$parent.selectElementById(this.id);
-            } else if (this.$root && this.$root?.schema && typeof this.$root.selectElementById === 'function') {
-                this.$root.selectElementById(this.id);
-            }
+            this.$emit("on-select-id", this.id)
         },
     },
     props: ['id'],

--- a/components/shuffle-column.js
+++ b/components/shuffle-column.js
@@ -1,16 +1,26 @@
 Vue.component('shuffle-column', {
     data: function () {
-      return {}
+        return {}
     },
     methods: {
-        onFocus: function() {
-            this.$root.selectElementById(this.id);
-        }
+        onFocus: function () {
+            if (typeof this.selectElementById === 'function') {
+                this.selectElementById(this.id);
+            }
+        },
+        selectElementById(id) {
+            const parent = this.$parent;
+            if (parent && parent?.schema && typeof this.selectElementById === 'function') {
+                this.$parent.selectElementById(this.id);
+            } else if (this.$root && this.$root?.schema && typeof this.$root.selectElementById === 'function') {
+                this.$root.selectElementById(this.id);
+            }
+        },
     },
     props: ['id'],
     template: `
-    <div @focus="onFocus" tabindex="-1"class="flex flex-col w-fit h-fit p-2 space-y-2 justify-center items-center bg-green-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2" > 
+    <div @focus="onFocus" tabindex="-1" class="flex flex-col w-fit h-fit p-2 space-y-2 justify-center items-center bg-green-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2" > 
         <slot></slot>
     </div>
     `,
-  });
+});

--- a/components/shuffle-column.js
+++ b/components/shuffle-column.js
@@ -10,7 +10,7 @@ Vue.component('shuffle-column', {
     },
     props: ['id'],
     template: `
-    <div @focus="onFocus" tabindex="-1" class="flex flex-col w-fit h-fit p-2 space-y-2 justify-center items-center bg-green-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2" > 
+    <div @focus="onFocus" tabindex="-1" class="flex flex-col w-fit h-fit p-2 space-y-2 justify-center items-center bg-green-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2"> 
         <slot></slot>
     </div>
     `,

--- a/components/shuffle-filter-intersection.js
+++ b/components/shuffle-filter-intersection.js
@@ -1,10 +1,10 @@
 Vue.component('shuffle-filter-intersection', {
     data: function () {
-      return {}
+        return {}
     },
     methods: {
-        onFocus: function() {
-            this.$root.selectElementById(this.id);
+        onFocus: function () {
+            this.$emit("on-select-id", this.id)
         }
     },
     props: ['id'],
@@ -17,4 +17,4 @@ Vue.component('shuffle-filter-intersection', {
         <div class="flex-none text-gray-400">-</div>
     </div>
     `,
-  });
+});

--- a/components/shuffle-filter-intersection.js
+++ b/components/shuffle-filter-intersection.js
@@ -1,0 +1,20 @@
+Vue.component('shuffle-filter-intersection', {
+    data: function () {
+      return {}
+    },
+    methods: {
+        onFocus: function() {
+            this.$root.selectElementById(this.id);
+        }
+    },
+    props: ['id'],
+    template: `
+    <div class="flex items-center">
+        <div class="flex-none text-gray-400">-</div>
+        <div @focus="onFocus" tabindex="-1" class="flex h-16 w-16 justify-center items-center bg-stone-300 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2">
+            <span class="text-gray-600">{{id}}</span>
+        </div>
+        <div class="flex-none text-gray-400">-</div>
+    </div>
+    `,
+  });

--- a/components/shuffle-filter.js
+++ b/components/shuffle-filter.js
@@ -2,19 +2,10 @@ Vue.component('shuffle-filter', {
     data: function () {
         return {}
     },
+    emits: ['on-select-id'],
     methods: {
         onFocus: function () {
-            if (typeof this.selectElementById === 'function') {
-                this.selectElementById(this.id);
-            }
-        },
-        selectElementById(id) {
-            const parent = this.$parent;
-            if (parent && parent?.schema && typeof this.selectElementById === 'function') {
-                this.$parent.selectElementById(this.id);
-            } else if (this.$root && this.$root?.schema && typeof this.$root.selectElementById === 'function') {
-                this.$root.selectElementById(this.id);
-            }
+            this.$emit("on-select-id", this.id)
         },
     },
     props: ['id'],

--- a/components/shuffle-filter.js
+++ b/components/shuffle-filter.js
@@ -10,8 +10,12 @@ Vue.component('shuffle-filter', {
     },
     props: ['id'],
     template: `
-    <div @focus="onFocus" tabindex="-1" class="flex h-16 w-16 justify-center items-center bg-gray-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2">
-        {{id}}
+    <div class="flex items-center">
+        <div class="flex-none text-gray-400">-</div>
+        <div @focus="onFocus" tabindex="-1" class="flex h-16 w-16 justify-center items-center bg-gray-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2">
+            <span class="text-gray-600">{{id}}</span>
+        </div>
+        <div class="flex-none text-gray-400">-</div>
     </div>
     `,
 });

--- a/components/shuffle-filter.js
+++ b/components/shuffle-filter.js
@@ -1,11 +1,21 @@
 Vue.component('shuffle-filter', {
     data: function () {
-      return {}
+        return {}
     },
     methods: {
-        onFocus: function() {
-            this.$root.selectElementById(this.id);
-        }
+        onFocus: function () {
+            if (typeof this.selectElementById === 'function') {
+                this.selectElementById(this.id);
+            }
+        },
+        selectElementById(id) {
+            const parent = this.$parent;
+            if (parent && parent?.schema && typeof this.selectElementById === 'function') {
+                this.$parent.selectElementById(this.id);
+            } else if (this.$root && this.$root?.schema && typeof this.$root.selectElementById === 'function') {
+                this.$root.selectElementById(this.id);
+            }
+        },
     },
     props: ['id'],
     template: `
@@ -13,4 +23,4 @@ Vue.component('shuffle-filter', {
         {{id}}
     </div>
     `,
-  });
+});

--- a/components/shuffle-param.js
+++ b/components/shuffle-param.js
@@ -1,0 +1,8 @@
+// ShuffleParam component
+Vue.component('shuffle-param', {
+    props: ['name', 'type', 'source', 'value'],
+    template: `
+            <div>
+            </div>
+            `,
+});

--- a/components/shuffle-params-group.js
+++ b/components/shuffle-params-group.js
@@ -1,0 +1,8 @@
+// ShuffleParamsGroup component
+Vue.component('shuffle-params-group', {
+    template: `
+    <div>
+        <slot></slot>
+    </div>
+    `,
+});

--- a/components/shuffle-row.js
+++ b/components/shuffle-row.js
@@ -1,20 +1,12 @@
 Vue.component('shuffle-row', {
     data: function () {
-        return {}
+        return {
+        }
     },
+    emits: ['on-select-id'],
     methods: {
         onFocus: function () {
-            if (typeof this.selectElementById === 'function') {
-                this.selectElementById(this.id);
-            }
-        },
-        selectElementById(id) {
-            const parent = this.$parent;
-            if (parent && parent?.schema && typeof this.selectElementById === 'function') {
-                this.$parent.selectElementById(this.id);
-            } else if (this.$root && this.$root?.schema && typeof this.$root.selectElementById === 'function') {
-                this.$root.selectElementById(this.id);
-            }
+            this.$emit("on-select-id", this.id)
         },
     },
     props: ['id'],

--- a/components/shuffle-row.js
+++ b/components/shuffle-row.js
@@ -11,7 +11,7 @@ Vue.component('shuffle-row', {
     },
     props: ['id'],
     template: `
-    <div @focus="onFocus" tabindex="-1" class="flex flex-row w-fit h-fit p-2 space-x-2 justify-center items-center bg-blue-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2" > 
+    <div @focus="onFocus" tabindex="-1" class="flex flex-row w-fit h-fit p-2 space-x-2 justify-center items-center bg-blue-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2"> 
         <slot></slot>
     </div>
     `,

--- a/components/shuffle-row.js
+++ b/components/shuffle-row.js
@@ -1,16 +1,26 @@
 Vue.component('shuffle-row', {
     data: function () {
-      return {}
+        return {}
     },
     methods: {
-        onFocus: function() {
-            this.$root.selectElementById(this.id);
-        }
+        onFocus: function () {
+            if (typeof this.selectElementById === 'function') {
+                this.selectElementById(this.id);
+            }
+        },
+        selectElementById(id) {
+            const parent = this.$parent;
+            if (parent && parent?.schema && typeof this.selectElementById === 'function') {
+                this.$parent.selectElementById(this.id);
+            } else if (this.$root && this.$root?.schema && typeof this.$root.selectElementById === 'function') {
+                this.$root.selectElementById(this.id);
+            }
+        },
     },
     props: ['id'],
     template: `
-    <div @focus="onFocus" tabindex="-1"class="flex flex-row w-fit h-fit p-2 space-x-2 justify-center items-center bg-blue-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2" > 
+    <div @focus="onFocus" tabindex="-1" class="flex flex-row w-fit h-fit p-2 space-x-2 justify-center items-center bg-blue-100 outline-indigo-600 outline-1 hover:outline-dashed focus:outline focus:outline-2" > 
         <slot></slot>
     </div>
     `,
-  });
+});

--- a/components/shuffle-scheme.js
+++ b/components/shuffle-scheme.js
@@ -1,0 +1,9 @@
+// ShuffleScheme component
+Vue.component('shuffle-scheme', {
+    props: ['local', 'incoming'],
+    template: `
+    <div>
+        <slot></slot>
+    </div>
+    `,
+});

--- a/components/ui/collapse-extend-text.js
+++ b/components/ui/collapse-extend-text.js
@@ -1,0 +1,36 @@
+Vue.component('collapse-extend-text', {
+    props: {
+        text: {
+            type: String,
+            required: true,
+        },
+        maxLength: {
+            type: Number,
+            default: 100,
+        },
+    },
+    data() {
+        return {
+            expanded: false,
+        };
+    },
+    computed: {
+        truncatedText() {
+            return this.expanded ? this.text : this.text.slice(0, this.maxLength);
+        },
+        showToggleButton() {
+            return this.text.length > this.maxLength;
+        },
+    },
+    methods: {
+        toggleText() {
+            this.expanded = !this.expanded;
+        },
+    },
+    template: `
+    <div>
+      <p v-if="!expanded">{{ truncatedText }} <span v-if="showToggleButton" @click="toggleText" class="text-blue-500 cursor-pointer">...Read More</span></p>
+      <p v-else>{{ text }} <span v-if="showToggleButton" @click="toggleText" class="text-blue-500 cursor-pointer">Read Less</span></p>
+    </div>
+  `,
+});

--- a/components/ui/node-moving-subpanel.js
+++ b/components/ui/node-moving-subpanel.js
@@ -1,0 +1,86 @@
+Vue.component('node-moving-subpanel', {
+    props: {
+        selectedItem: Object,
+    },
+    emits: ['on-move-item', 'on-remove-item'],
+    data() {
+        return {
+            newItemType: "shuffle-column",
+        };
+    },
+    methods: {
+        addNewItem() {
+            switch (this.newItemType) {
+                case "shuffle-column":
+                    return this.addNewColumnItem()
+                case "shuffle-row":
+                    return this.addNewRowItem()
+                case "shuffle-filter":
+                    return this.addNewFilterItem()
+                default:
+                    throw new Error(`Unsupported type ${this.newItemType} for operate.`)
+            }
+        },
+        addNewFilterItem() {
+            const newItem = {
+                id: Math.random().toString(36).substr(2, 3),
+                type: this.newItemType,
+                result: !!Math.random(),
+            };
+            this.selectedItem.childs.push(newItem);
+        },
+        addNewColumnItem() {
+            const newItem = {
+                id: Math.random().toString(36).substr(2, 3),
+                type: this.newItemType,
+                childs: [],
+            };
+            this.selectedItem.childs.push(newItem);
+        },
+        addNewRowItem() {
+            const newItem = {
+                id: Math.random().toString(36).substr(2, 3),
+                type: this.newItemType,
+                childs: [],
+            };
+            this.selectedItem.childs.push(newItem);
+        },
+        moveItem(directionName) {
+            this.$emit("on-move-item", { direction: directionName, id: this.selectedItem.id })
+        },
+        deleteItem() {
+            this.$emit("on-remove-item", this.selectedItem.id)
+        },
+    },
+    template: `
+    <div v-if="selectedItem" class="node-moving-subpanel">
+        <div v-if="selectedItem.type === 'shuffle-column' || selectedItem.type === 'shuffle-row'">
+            <p>Новый элемент</p>
+            <div class="add-new-item">
+                <select v-model="newItemType">
+                    <option value="shuffle-column">Столбец</option>
+                    <option value="shuffle-row">Строку</option>
+                    <option value="shuffle-filter">Фильтр</option>
+                </select>
+                <button @click="addNewItem" class="px-6 py-1 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-r-lg focus:outline-none focus:ring focus:border-blue-300">Добавить</button>
+            </div>
+        </div>
+
+        <div v-if="selectedItem.type === 'shuffle-filter'">
+            <p>Перемещение</p>
+            <div class="move-item">
+                <button @click="moveItem('forward')" class="px-6 py-1 bg-yellow-300 hover:bg-yellow-200 text-amber-950 font-semibold rounded focus:outline-none focus:ring focus:bg-yellow-300">Вперед</button>
+                <button @click="moveItem('backward')" class="px-6 py-1 bg-lime-600 hover:bg-lime-500 text-white font-semibold rounded focus:outline-none focus:ring focus:bg-lime-600">Назад</button>
+            </div >
+        </div>
+
+        <div>
+            <p>Удаление</p>
+            <div class="move-item">
+                <button @click="deleteItem" class="px-6 py-1 bg-red-500 hover:bg-red-600 text-white font-semibold rounded focus:outline-none focus:ring focus:border-red-300">Удалить</button>
+            </div >
+        </div>
+    </div>
+    `,
+});
+

--- a/components/ui/node-moving-subpanel.js
+++ b/components/ui/node-moving-subpanel.js
@@ -53,31 +53,31 @@ Vue.component('node-moving-subpanel', {
         },
     },
     template: `
-    <div v-if="selectedItem" class="node-moving-subpanel">
+    <div v-if="selectedItem.type" class="node-moving-subpanel">
         <div v-if="selectedItem.type === 'shuffle-column' || selectedItem.type === 'shuffle-row'">
-            <p>Новый элемент</p>
+            <p>New</p>
             <div class="add-new-item">
                 <select v-model="newItemType">
-                    <option value="shuffle-column">Столбец</option>
-                    <option value="shuffle-row">Строку</option>
-                    <option value="shuffle-filter">Фильтр</option>
+                    <option value="shuffle-column">shuffle-column</option>
+                    <option value="shuffle-row">shuffle-row</option>
+                    <option value="shuffle-filter">shuffle-filter</option>
                 </select>
-                <button @click="addNewItem" class="px-6 py-1 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-r-lg focus:outline-none focus:ring focus:border-blue-300">Добавить</button>
+                <button @click="addNewItem" class="px-6 py-1 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-r-lg focus:outline-none focus:ring focus:border-blue-300">Add new</button>
             </div>
         </div>
 
         <div v-if="selectedItem.type === 'shuffle-filter'">
-            <p>Перемещение</p>
+            <p>Move</p>
             <div class="move-item">
-                <button @click="moveItem('forward')" class="px-6 py-1 bg-yellow-300 hover:bg-yellow-200 text-amber-950 font-semibold rounded focus:outline-none focus:ring focus:bg-yellow-300">Вперед</button>
-                <button @click="moveItem('backward')" class="px-6 py-1 bg-lime-600 hover:bg-lime-500 text-white font-semibold rounded focus:outline-none focus:ring focus:bg-lime-600">Назад</button>
+                <button @click="moveItem('forward')" class="px-6 py-1 bg-yellow-300 hover:bg-yellow-200 text-amber-950 font-semibold rounded focus:outline-none focus:ring focus:bg-yellow-300">Forward</button>
+                <button @click="moveItem('backward')" class="px-6 py-1 bg-lime-600 hover:bg-lime-500 text-white font-semibold rounded focus:outline-none focus:ring focus:bg-lime-600">Backward</button>
             </div >
         </div>
 
         <div>
-            <p>Удаление</p>
+            <p>Delete</p>
             <div class="move-item">
-                <button @click="deleteItem" class="px-6 py-1 bg-red-500 hover:bg-red-600 text-white font-semibold rounded focus:outline-none focus:ring focus:border-red-300">Удалить</button>
+                <button @click="deleteItem" class="px-6 py-1 bg-red-500 hover:bg-red-600 text-white font-semibold rounded focus:outline-none focus:ring focus:border-red-300">Delete</button>
             </div >
         </div>
     </div>

--- a/components/ui/node-panel.js
+++ b/components/ui/node-panel.js
@@ -1,15 +1,59 @@
 Vue.component('node-panel', {
     props: {
+        schema: Object,
         selectedItem: Object,
     },
     data() {
         return {
         };
     },
+    computed: {
+        serializedSelectedItem() {
+            return JSON.stringify(this.selectedItem);
+        },
+    },
     methods: {
+        selectElementById(id) {
+            return searchInSchemeById(this.$props.schema, id)
+        },
+        selectParentById(id) {
+            return findParentShuffleElement(this.$props.schema, id)
+        },
         getSchemeResult: function (scheme) {
             return runScheme(scheme);
-        }
+        },
+        handlerOnMoveItem: function ({ direction, id }) {
+            const parent = this.selectParentById(id)
+
+            if (parent) {
+                const index = this.selectedItem.id
+                    ? parent.childs.findIndex((child) => child.id === this.selectedItem.id)
+                    : parent.childs.findIndex((child) => child === this.selectedItem);
+
+                if (-1 !== index) {
+                    if (direction === "forward" && index < parent.childs.length - 1) {
+                        parent.childs.splice(index, 1);
+                        parent.childs.splice(index + 1, 0, this.selectedItem);
+                    } else if (direction === "backward" && index > 0) {
+                        parent.childs.splice(index, 1);
+                        parent.childs.splice(index - 1, 0, this.selectedItem);
+                    }
+                }
+            }
+        },
+        handlerOnRemoveItem: function (id) {
+            const parent = this.selectParentById(id)
+
+            if (parent) {
+                const index = this.selectedItem.id
+                    ? parent.childs.findIndex((child) => child.id === this.selectedItem.id)
+                    : parent.childs.findIndex((child) => child === this.selectedItem);
+
+                if (-1 !== index) {
+                    parent.childs.splice(index, 1);
+                }
+            }
+        },
     },
     template: `
     <div v-if="selectedItem" class="flex flex-col border-1 border">
@@ -54,11 +98,20 @@ Vue.component('node-panel', {
         <div class="flex bg-gray-200 p-2 rounded-b-lg">
             <h2 class="text-bold">Result</h2>
         </div>
-        <div class="flex flex-col p-2">
+        <div class="flex flex-col p-2 small">
             <div>getSchemeResult: {{ getSchemeResult(selectedItem) }}</div>
         </div>
+        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+            <h2 class="text-bold">Операции</h2>
+        </div>
         <div class="flex flex-col p-2">
-            {{ selectedItem }}
+            <node-moving-subpanel :selected-item="selectedItem" @on-move-item="handlerOnMoveItem" @on-remove-item="handlerOnRemoveItem" />
+        </div>
+        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+            <h2 class="text-bold">Выбранный элемент</h2>
+        </div>
+        <div class="flex flex-col p-2">
+            <collapse-extend-text :text="serializedSelectedItem" :maxLength="10" />
         </div>
     </div>
     `,

--- a/components/ui/node-panel.js
+++ b/components/ui/node-panel.js
@@ -1,0 +1,66 @@
+Vue.component('node-panel', {
+    props: {
+        selectedItem: Object,
+    },
+    data() {
+        return {
+        };
+    },
+    methods: {
+        getSchemeResult: function (scheme) {
+            return runScheme(scheme);
+        }
+    },
+    template: `
+    <div v-if="selectedItem" class="flex flex-col border-1 border">
+        <div>
+            <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                <h2 class="text-bold">Properties</h2>
+            </div>
+            <div class="flex flex-col p-2">
+                <div v-if="selectedItem.id">
+                    <div v-if="'shuffle-filter' == selectedItem.type">
+                        <input v-model="selectedItem.id" />
+                    </div>
+                    <span v-else>{{ selectedItem.id }}</span>
+                    
+                </div>
+
+                <div v-if="selectedItem.type">
+                    <span>{{ selectedItem.type }}</span>
+                </div>
+
+                <div v-if="selectedItem.result != null" class="text-gray-400">
+                    <div v-if="'shuffle-filter' == selectedItem.type">
+                        <input v-model="selectedItem.result" />
+                    </div>
+                    <span v-else>{{ selectedItem.result }}</span>
+                </div>
+            </div>
+        </div>
+        <div v-if="selectedItem.childs">
+            <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                <h2 class="text-bold">
+                    <span class="capitalize">{{ selectedItem.type }}</span> childs
+                </h2>
+            </div>
+            
+            <div class="flex flex-col p-2">
+                <div v-for="child in selectedItem.childs" :key="child.id">
+                {{ child.id }}: {{ child.type }} <span class="text-gray-400"> -> {{ getSchemeResult(child) }}</span>
+                </div>
+            </div>
+        </div>
+        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+            <h2 class="text-bold">Result</h2>
+        </div>
+        <div class="flex flex-col p-2">
+            <div>getSchemeResult: {{ getSchemeResult(selectedItem) }}</div>
+        </div>
+        <div class="flex flex-col p-2">
+            {{ selectedItem }}
+        </div>
+    </div>
+    `,
+});
+

--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
                     <shuffle-row id="Main" >
                         <shuffle-column id="D">
                             <shuffle-row id="A">
-                                <shuffle-filter id="A1"></shuffle-filter>
-                                <shuffle-filter id="A2"></shuffle-filter>
+                                <shuffle-filter-intersection id="A1"></shuffle-filter-intersection>
+                                <shuffle-filter-intersection id="A2"></shuffle-filter-intersection>
                             </shuffle-row>
                             <shuffle-column id="B">
                                 <shuffle-filter id="B1"></shuffle-filter>
@@ -105,11 +105,14 @@
                         <div>
                             id: {{ selectedItem.id }}
                         </div>
-                        <div>
+                        <div v-if="selectedItem.type=='filter-intersection'">
+                            type: <span class="bg-stone-300 rounded p-1">{{ selectedItem.type }}</span>
+                        </div>
+                        <div v-else>
                             type: {{ selectedItem.type }}
                         </div>
                         <div v-if="selectedItem.result!=null" class="text-gray-400">
-                            result: {{selectedItem.result}}
+                            mock-result: {{selectedItem.result}}
                         </div>
                     </div>
                 </div>
@@ -187,6 +190,7 @@
     <script src="components/ui/node-moving-subpanel.js"></script>
     <script src="components/ui/node-panel.js"></script>
     <script src="components/shuffle-filter.js"></script>
+    <script src="components/shuffle-filter-intersection.js"></script>
     <script src="components/shuffle-column.js"></script>
     <script src="components/shuffle-row.js"></script>
     <script src="components/shuffle-chain.js"></script>

--- a/index.html
+++ b/index.html
@@ -34,58 +34,18 @@
                         <shuffle-chain :schema="secondScheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
                     </div>
                 </div>
-                <div class="sidebar bg-gray-100">
-                    <div v-if="selectedItem" class="flex flex-col border-1 border">
-                        <div>
-                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                            <h2 class="text-bold">Properties</h2>
-                        </div>
-                        <div class="flex flex-col p-2">
-                            <div v-if="selectedItem.id">
-                            id: {{ selectedItem.id }}
-                            </div>
-                            <div v-if="selectedItem.type">
-                            type: {{ selectedItem.type }}
-                            </div>
-                            <div v-if="selectedItem.result != null" class="text-gray-400">
-                            result: {{ selectedItem.result }}
-                            </div>
-                        </div>
-                        </div>
-                        <div v-if="selectedItem.childs">
-                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                            <h2 class="text-bold">
-                            <span class="capitalize">{{ selectedItem.type }}</span> childs
-                            </h2>
-                        </div>
-                        <div class="flex flex-col p-2">
-                            <div v-for="child in selectedItem.childs" :key="child.id">
-                            {{ child.id }}: {{ child.type }} <span class="text-gray-400"> -> {{ getSchemeResult(child) }}</span>
-                            </div>
-                        </div>
-                        </div>
-                        <div>
-                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                            <h2 class="text-bold">
-                            Result
-                            </h2>
-                        </div>
-                        <div class="flex flex-col p-2">
-                            <div>
-                            getSchemeResult: {{ getSchemeResult(selectedItem) }}
-                            </div>
-                        </div>
-                        </div>
-                    </div>
-                    <div v-else class="p-4">
-                        {{ message }}
-                    </div>
+                <div v-if="selectedItem" class="sidebar bg-gray-100">
+                    <node-panel :selected-item="selectedItem" />
+                </div>
+                <div v-else class="p-4">
+                    {{ message }}
                 </div>
             </div>
         </div>      
     </div>
 
-    <script src="./schemas.js"></script>
+    <script src="./schemas.js"></script>  
+    <script src="components/ui/node-panel.js"></script>
     <script src="components/shuffle-filter.js"></script>
     <script src="components/shuffle-column.js"></script>
     <script src="components/shuffle-row.js"></script>

--- a/index.html
+++ b/index.html
@@ -23,30 +23,163 @@
 </head>
 
 <body>
-    <div id="app" tabindex="-1" class="flex h-screen w-screen bg-white">
-        <div v-if="varsOfSchemes && varsOfSchemes.length" class="fixed top-0 left-0 z-50 bg-white py-2 px-4">
-            <span>Рабочая схема:</span>
-            <select v-model="selectedScheme">
-                <template v-for="item in varsOfSchemes">
-                    <option :value="item.value" selected="selectedChain.name == item.name">{{ item.name }}</option-->
-                </template>
-            </select>
-        </div>
-        <div class="app-container">
-            <div class="flex h-screen w-screen bg-white">
-                <div class="flex-grow bg-white py-16 px-4 overflow-scroll">
-                    <div v-if="selectedScheme" class="flex-grow bg-white py-16 px-4">
-                        <shuffle-chain :schema="selectedScheme" @on-select-item="onSelectItem" />
+    <div id="app" @focus="onFocus" tabindex="-1" class="flex h-screen w-screen space-x-2 bg-white">
+
+        <!-- White board -->
+        <div class="flex flex-grow bg-white py-16 px-4 items-center space-x-2 overflow-scroll">
+
+            <!-- Params -->
+            <div class="flex flex-col space-y-2 border p-4">
+
+                <!-- Incoming -->
+                <div class="flex flex-col w-80 h-fit p-2 space-y-2 border border-blue-100 justify-center items-strech">
+                    <div class="flex justify-start">Incoming params:</div>
+                    <div v-for="(value, key) in incoming" :key="key" class="flex bg-gray-100 p-2 justify-start text-sm">
+                        {{key}}: {{value}}
                     </div>
                 </div>
-                <div v-if="selectedItem" class="sidebar bg-gray-100">
-                    <node-panel :schema="selectedScheme" :selected-item="selectedItem" />
+
+            </div>
+
+            <div class="flex-none">
+                ->
+            </div>
+            
+            <div class="flex flex-col space-y-4 border p-4">
+
+                <!-- Scheme -->
+                <div class="flex flex-col w-fit h-fit p-2 space-y-2 border justify-center items-strech">
+                    <div class="flex justify-start">Scheme:</div>
+
+                    <shuffle-row id="Main" >
+                        <shuffle-column id="D">
+                            <shuffle-row id="A">
+                                <shuffle-filter id="A1"></shuffle-filter>
+                                <shuffle-filter id="A2"></shuffle-filter>
+                            </shuffle-row>
+                            <shuffle-column id="B">
+                                <shuffle-filter id="B1"></shuffle-filter>
+                                <shuffle-filter id="B2"></shuffle-filter>
+                            </shuffle-column>
+                        </shuffle-column>
+                        <shuffle-filter id="C1"></shuffle-filter>
+                        <shuffle-column id="Z">
+                            <shuffle-filter id="Z1"></shuffle-filter>
+                            <shuffle-filter id="Z2"></shuffle-filter>
+                        </shuffle-column>
+                    </shuffle-row>
+
                 </div>
-                <div v-else class="p-4">
-                    {{ message }}
+
+                <!-- Local -->
+                <div class="flex flex-col w-80 h-fit p-2 space-y-2 border justify-center items-strech">
+                    <div class="flex justify-start">Local params:</div>
+                    <div v-for="(value, key) in local" :key="key" class="flex bg-gray-100 p-2 justify-start text-sm">
+                        {{key}}: {{value}}
+                    </div>
+                </div>
+
+            </div>
+
+            <div class="flex-none">
+                ->
+            </div>
+
+            <!-- Result -->
+            <div class="flex p-4 border">
+                1/0
+            </div>
+
+        </div>
+
+        <!-- Side Menu -->
+        <div class="flex-none w-64 bg-gray-100">
+            <div v-if="selectedItem" class="flex flex-col border-1 border">
+                
+                <!-- Properties -->
+                <div>
+                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                        <h2 class="text-bold">Properties</h2>
+                    </div>
+                    <div class="flex flex-col p-2">
+                        <div>
+                            id: {{ selectedItem.id }}
+                        </div>
+                        <div>
+                            type: {{ selectedItem.type }}
+                        </div>
+                        <div v-if="selectedItem.result!=null" class="text-gray-400">
+                            result: {{selectedItem.result}}
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Childs -->
+                <div v-if="selectedItem.childs">
+                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                        <h2 class="text-bold">
+                            <span class="capitalize">{{selectedItem.type}}</span> childs
+                        </h2>
+                    </div>
+                    <div class="flex flex-col p-2">
+                        <div v-for="child in selectedItem.childs" :key="child.id">
+                            {{ child.id }}: {{child.type}} <span class="text-gray-400"> -> {{getSchemeResult(child)}}</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Params -->
+                <div v-for="param in selectedItem.params" :key="param.name">
+                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                        <h2 class="text-bold">
+                            Param {{param.name}}
+                        </h2>
+                    </div>
+                    <div class="flex flex-col p-2">
+                        <div>
+                            name: {{ param.name }}
+                        </div>
+                        <div>
+                            type: {{ param.type }}
+                        </div>
+                        <div>
+                            source: {{param.source}}
+                        </div>
+                        <div v-if="param.key">
+                            key: {{param.key}}
+                        </div>
+                        <div v-if="param.source=='inline'">
+                            inline-value: {{param.value}}
+                        </div>
+                        <div v-if="param.source=='local'" class="text-gray-400">
+                            local-value: {{local[param.key]}}
+                        </div>
+                        <div v-if="param.source=='incoming'" class="text-gray-400">
+                            incoming-value: {{incoming[param.key]}}
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Result -->
+                <div>
+                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                        <h2 class="text-bold">
+                            Result
+                        </h2>
+                    </div>
+                    <div class="flex flex-col p-2">
+                        <div>
+                            getSchemeResult: {{getSchemeResult(selectedItem)}}
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>      
+            <!-- Nothing selected message -->
+            <div v-else class="p-4">
+                {{message}}
+            </div>
+        </div>
+        
     </div>
 
     <script src="./schemas.js"></script>  

--- a/index.html
+++ b/index.html
@@ -23,19 +23,24 @@
 </head>
 
 <body>
-    <div id="app" @focus="onFocus" tabindex="-1" class="flex h-screen w-screen bg-white">
-        <div id="app" class="app-container">
+    <div id="app" tabindex="-1" class="flex h-screen w-screen bg-white">
+        <div v-if="varsOfSchemes && varsOfSchemes.length" class="fixed top-0 left-0 z-50 bg-white py-2 px-4">
+            <span>Рабочая схема:</span>
+            <select v-model="selectedScheme">
+                <template v-for="item in varsOfSchemes">
+                    <option :value="item.value" selected="selectedChain.name == item.name">{{ item.name }}</option-->
+                </template>
+            </select>
+        </div>
+        <div class="app-container">
             <div class="flex h-screen w-screen bg-white">
                 <div class="flex-grow bg-white py-16 px-4 overflow-scroll">
-                    <div class="flex-grow bg-white py-16 px-4">
-                        <shuffle-chain :schema="scheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
-                    </div>
-                    <div class="flex-grow bg-white py-16 px-4">
-                        <shuffle-chain :schema="secondScheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
+                    <div v-if="selectedScheme" class="flex-grow bg-white py-16 px-4">
+                        <shuffle-chain :schema="selectedScheme" @on-select-item="onSelectItem" />
                     </div>
                 </div>
                 <div v-if="selectedItem" class="sidebar bg-gray-100">
-                    <node-panel :selected-item="selectedItem" />
+                    <node-panel :schema="selectedScheme" :selected-item="selectedItem" />
                 </div>
                 <div v-else class="p-4">
                     {{ message }}
@@ -45,6 +50,8 @@
     </div>
 
     <script src="./schemas.js"></script>  
+    <script src="components/ui/collapse-extend-text.js"></script>
+    <script src="components/ui/node-moving-subpanel.js"></script>
     <script src="components/ui/node-panel.js"></script>
     <script src="components/shuffle-filter.js"></script>
     <script src="components/shuffle-column.js"></script>

--- a/index.html
+++ b/index.html
@@ -6,88 +6,90 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.8/dist/vue.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .app-container {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+        .flex-grow {
+            flex-grow: 1;
+        }
+        .sidebar {
+            width: 20rem;
+            flex-shrink: 0;
+        }
+    </style>
 </head>
 
 <body>
     <div id="app" @focus="onFocus" tabindex="-1" class="flex h-screen w-screen bg-white">
-
-        <div class="flex flex-grow bg-white py-16 px-4 overflow-scroll">
-            <shuffle-row id="Main" >
-                <shuffle-column id="D">
-                    <shuffle-row id="A">
-                        <shuffle-filter id="A1"></shuffle-filter>
-                        <shuffle-filter id="A2"></shuffle-filter>
-                    </shuffle-row>
-                    <shuffle-column id="B">
-                        <shuffle-filter id="B1"></shuffle-filter>
-                        <shuffle-filter id="B2"></shuffle-filter>
-                    </shuffle-column>
-                </shuffle-column>
-                <shuffle-filter id="C1"></shuffle-filter>
-                <shuffle-column id="Z">
-                    <shuffle-filter id="Z1"></shuffle-filter>
-                    <shuffle-filter id="Z2"></shuffle-filter>
-                </shuffle-column>
-            </shuffle-row>
-
-            
-
-        </div>
-        
-        <div class="w-64 bg-gray-100">
-            <div v-if="selectedItem" class="flex flex-col border-1 border">
-                <div>
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">Properties</h2>
+        <div id="app" class="app-container">
+            <div class="flex h-screen w-screen bg-white">
+                <div class="flex-grow bg-white py-16 px-4 overflow-scroll">
+                    <div class="flex-grow bg-white py-16 px-4">
+                        <shuffle-chain :schema="scheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
                     </div>
-                    <div class="flex flex-col p-2">
+                    <div class="flex-grow bg-white py-16 px-4">
+                        <shuffle-chain :schema="secondScheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
+                    </div>
+                </div>
+                <div class="sidebar bg-gray-100">
+                    <div v-if="selectedItem" class="flex flex-col border-1 border">
                         <div>
+                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                            <h2 class="text-bold">Properties</h2>
+                        </div>
+                        <div class="flex flex-col p-2">
+                            <div v-if="selectedItem.id">
                             id: {{ selectedItem.id }}
-                        </div>
-                        <div>
+                            </div>
+                            <div v-if="selectedItem.type">
                             type: {{ selectedItem.type }}
+                            </div>
+                            <div v-if="selectedItem.result != null" class="text-gray-400">
+                            result: {{ selectedItem.result }}
+                            </div>
                         </div>
-                        <div v-if="selectedItem.result!=null" class="text-gray-400">
-                            result: {{selectedItem.result}}
                         </div>
-                    </div>
-                </div>
-                <div v-if="selectedItem.childs">
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">
-                            <span class="capitalize">{{selectedItem.type}}</span> childs
-                        </h2>
-                    </div>
-                    <div class="flex flex-col p-2">
-                        <div v-for="child in selectedItem.childs" :key="child.id">
-                            {{ child.id }}: {{child.type}} <span class="text-gray-400"> -> {{getSchemeResult(child)}}</span>
+                        <div v-if="selectedItem.childs">
+                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                            <h2 class="text-bold">
+                            <span class="capitalize">{{ selectedItem.type }}</span> childs
+                            </h2>
                         </div>
-                    </div>
-                </div>
-                <div>
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">
-                            Result
-                        </h2>
-                    </div>
-                    <div class="flex flex-col p-2">
+                        <div class="flex flex-col p-2">
+                            <div v-for="child in selectedItem.childs" :key="child.id">
+                            {{ child.id }}: {{ child.type }} <span class="text-gray-400"> -> {{ getSchemeResult(child) }}</span>
+                            </div>
+                        </div>
+                        </div>
                         <div>
-                            getSchemeResult: {{getSchemeResult(selectedItem)}}
+                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                            <h2 class="text-bold">
+                            Result
+                            </h2>
+                        </div>
+                        <div class="flex flex-col p-2">
+                            <div>
+                            getSchemeResult: {{ getSchemeResult(selectedItem) }}
+                            </div>
+                        </div>
                         </div>
                     </div>
+                    <div v-else class="p-4">
+                        {{ message }}
+                    </div>
                 </div>
-                
             </div>
-            <div v-else class="p-4">
-                {{message}}
-            </div>
-        </div>
-        
+        </div>      
     </div>
 
+    <script src="./schemas.js"></script>
     <script src="components/shuffle-filter.js"></script>
     <script src="components/shuffle-column.js"></script>
     <script src="components/shuffle-row.js"></script>
+    <script src="components/shuffle-chain.js"></script>
     <script src="libs/schemeSearch.js"></script>
     <script src="libs/schemeRunner.js"></script>
     <script src="app.js"></script>

--- a/index.html
+++ b/index.html
@@ -23,112 +23,24 @@
 </head>
 
 <body>
-    <div id="app" @focus="onFocus" tabindex="-1" class="flex h-screen w-screen space-x-2 bg-white">
-
-        <!-- White board -->
-        <div class="flex flex-grow bg-white py-16 px-4 items-center space-x-2 overflow-scroll">
-
-            <!-- Params -->
-            <div class="flex flex-col space-y-2 border p-4">
-
-                <!-- Incoming -->
-                <div class="flex flex-col w-80 h-fit p-2 space-y-2 border border-blue-100 justify-center items-strech">
-                    <div class="flex justify-start">Incoming params:</div>
-                    <div v-for="(value, key) in incoming" :key="key" class="flex bg-gray-100 p-2 justify-start text-sm">
-                        {{key}}: {{value}}
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="flex-none text-gray-400">
-                ->
-            </div>
-            
-            <div class="flex flex-col space-y-4 border p-4">
-
-                <!-- Scheme -->
-                <div class="flex flex-col w-fit h-fit p-2 space-y-2 border justify-center items-strech">
-                    <div class="flex justify-start">Scheme:</div>
-
-                    <shuffle-row id="Main" >
-                        <shuffle-column id="D">
-                            <shuffle-row id="A">
-                                <shuffle-filter-intersection id="A1"></shuffle-filter-intersection>
-                                <shuffle-filter-intersection id="A2"></shuffle-filter-intersection>
-                            </shuffle-row>
-                            <shuffle-column id="B">
-                                <shuffle-filter id="B1"></shuffle-filter>
-                                <shuffle-filter id="B2"></shuffle-filter>
-                            </shuffle-column>
-                        </shuffle-column>
-                        <shuffle-filter id="C1"></shuffle-filter>
-                        <shuffle-column id="Z">
-                            <shuffle-filter id="Z1"></shuffle-filter>
-                            <shuffle-filter id="Z2"></shuffle-filter>
-                        </shuffle-column>
-                    </shuffle-row>
-
-                </div>
-
-                <!-- Local -->
-                <div class="flex flex-col w-80 h-fit p-2 space-y-2 border justify-center items-strech">
-                    <div class="flex justify-start">Local params:</div>
-                    <div v-for="(value, key) in local" :key="key" class="flex bg-gray-100 p-2 justify-start text-sm">
-                        {{key}}: {{value}}
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="flex-none text-gray-400">
-                ->
-            </div>
-
-            <!-- Result -->
-            <div class="flex p-4 border">
-                <span class="text-gray-600">1/0</span>
-            </div>
-
+    <div id="app" tabindex="-1" class="flex h-screen w-screen bg-white">
+        <div v-if="varsOfSchemes && varsOfSchemes.length" class="fixed top-0 left-0 z-50 bg-white py-2 px-4">
+            <span>Рабочая схема:</span>
+            <select v-model="selectedScheme">
+                <template v-for="item in varsOfSchemes">
+                    <option :value="item.value" selected="selectedChain.name == item.name">{{ item.name }}</option-->
+                </template>
+            </select>
         </div>
-
-        <!-- Side Menu -->
-        <div class="flex-none w-64 bg-gray-100">
-            <div v-if="selectedItem" class="flex flex-col border-1 border">
-                
-                <!-- Properties -->
-                <div>
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">Properties</h2>
-                    </div>
-                    <div class="flex-grow bg-white py-16 px-4">
-                        <shuffle-chain :schema="secondScheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
+        <div class="app-container">
+            <div class="flex h-screen w-screen bg-white">
+                <div class="flex-grow bg-white py-16 px-4 overflow-scroll">
+                    <div v-if="selectedScheme" class="flex-grow bg-white py-16 px-4">
+                        <shuffle-chain :schema="selectedScheme" @on-select-item="onSelectItem" />
                     </div>
                 </div>
-                <div class="sidebar bg-gray-100">
-                    <div v-if="selectedItem" class="flex flex-col border-1 border">
-                        <div>
-                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                            <h2 class="text-bold">Properties</h2>
-                        </div>
-                        <div class="flex flex-col p-2">
-                            <div v-if="selectedItem.id">
-                            id: {{ selectedItem.id }}
-                        </div>
-                        <div v-if="selectedItem.type=='filter-intersection'">
-                            type: <span class="bg-stone-300 rounded p-1">{{ selectedItem.type }}</span>
-                        </div>
-                        <div v-else>
-                            type: {{ selectedItem.type }}
-                            </div>
-                            <div v-if="selectedItem.result != null" class="text-gray-400">
-                            result: {{ selectedItem.result }}
-                            </div>
-                        </div>
-                        <div v-if="selectedItem.result!=null" class="text-gray-400">
-                            mock-result: {{selectedItem.result}}
-                        </div>
-                    </div>
+                <div v-if="selectedItem" class="sidebar bg-gray-100">
+                    <node-panel :schema="selectedScheme" :selected-item="selectedItem" />
                 </div>
 
                 <!-- Childs -->

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 
 <body>
     <div id="app" tabindex="-1" class="flex h-screen w-screen bg-white">
+        <!-- Top panel -->
         <div v-if="varsOfSchemes && varsOfSchemes.length" class="fixed top-0 left-0 z-50 bg-white py-2 px-4">
             <span>Рабочая схема:</span>
             <select v-model="selectedScheme">
@@ -32,105 +33,75 @@
                 </template>
             </select>
         </div>
-        <div class="app-container">
-            <div class="flex h-screen w-screen bg-white">
-                <div class="flex-grow bg-white py-16 px-4 overflow-scroll">
-                    <div v-if="selectedScheme" class="flex-grow bg-white py-16 px-4">
-                        <shuffle-chain :schema="selectedScheme" @on-select-item="onSelectItem" />
-                    </div>
-                </div>
-                <div v-if="selectedItem" class="sidebar bg-gray-100">
-                    <node-panel :schema="selectedScheme" :selected-item="selectedItem" />
-                </div>
 
-                <!-- Childs -->
-                <div v-if="selectedItem.childs">
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">
-                            <span class="capitalize">{{selectedItem.type}}</span> childs
-                        </h2>
-                    </div>
-                    <div class="flex flex-col p-2">
-                        <div v-for="child in selectedItem.childs" :key="child.id">
-                            {{ child.id }}: {{child.type}} <span class="text-gray-400"> -> {{getSchemeResult(child)}}</span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Params -->
-                <div v-for="param in selectedItem.params" :key="param.name">
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">
-                            Param {{param.name}}
-                        </h2>
-                    </div>
-                    <div class="flex flex-col p-2">
-                        <div>
-                            name: {{ param.name }}
-                        </div>
-                        <div>
-                            type: {{ param.type }}
-                        </div>
-                        <div>
-                            source: {{param.source}}
-                        </div>
-                        <div v-if="param.key">
-                            key: {{param.key}}
-                        </div>
-                        <div v-if="param.source=='inline'">
-                            inline-value: {{param.value}}
-                        </div>
-                        <div v-if="param.source=='local'" class="text-gray-400">
-                            local-value: {{local[param.key]}}
-                        </div>
-                        <div v-if="param.source=='incoming'" class="text-gray-400">
-                            incoming-value: {{incoming[param.key]}}
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Result -->
-                <div>
-                    <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                        <h2 class="text-bold">
-                            Result
-                        </h2>
-                    </div>
-                    <div class="flex flex-col p-2">
-                        <div>
-                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
-                            <h2 class="text-bold">
-                            Result
-                            </h2>
-                        </div>
-                        <div class="flex flex-col p-2">
-                            <div>
-                            getSchemeResult: {{ getSchemeResult(selectedItem) }}
-                            </div>
-                        </div>
-                        </div>
-                    </div>
-                    <div v-else class="p-4">
-                        {{ message }}
+        <!-- White board -->
+        <div class="flex flex-grow bg-white py-16 px-4 items-center space-x-2 overflow-scroll">
+            <!-- Params -->
+            <div class="flex flex-col space-y-2 border p-4">
+                <!-- Incoming -->
+                <div class="flex flex-col w-80 h-fit p-2 space-y-2 border border-blue-100 justify-center items-strech">
+                    <div class="flex justify-start">Incoming params:</div>
+                    <div v-for="(value, key) in incoming" :key="key" class="flex bg-gray-100 p-2 justify-start text-sm">
+                        {{key}}: {{value}}
                     </div>
                 </div>
             </div>
-            <!-- Nothing selected message -->
-            <div v-else class="p-4">
-                {{message}}
+
+            <div class="flex-none text-gray-400">
+                ->
+            </div>
+        
+            <div class="flex flex-col space-y-4 border p-4">
+                <!-- Scheme -->
+                <div class="flex flex-col w-fit h-fit p-2 space-y-2 border justify-center items-strech">
+                    <div class="flex justify-start">Scheme</div>
+                    <shuffle-scheme :local="local" :incoming="incoming">
+                        <shuffle-params-group>
+                            <shuffle-param name="Alpha" type="set" source="inline" :value="['cafe', 'kids', 'beach']" />
+                            <shuffle-param name="Beta" type="set" source="local" :value="local['ballooning-fest']" />
+                            <shuffle-param name="Gamma" type="set" source="incoming" :value="incoming['place']" />
+                        </shuffle-params-group>
+                        <shuffle-chain :schema="selectedScheme" @on-select-item="onSelectItem" />
+                    </shuffle-scheme>
+                </div>
+
+                <!-- Local -->
+                <div class="flex flex-col w-80 h-fit p-2 space-y-2 border justify-center items-strech">
+                    <div class="flex justify-start">Local params:</div>
+                    <div v-for="(value, key) in local" :key="key" class="flex bg-gray-100 p-2 justify-start text-sm">
+                        {{key}}: {{value}}
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex-none text-gray-400">
+                ->
+            </div>
+            <!-- Result -->
+            <div class="flex p-4 border">
+                <span class="text-gray-600">1/0</span>
+            </div>   
+        </div>
+
+        <!-- Side Menu -->
+        <div class="flex-grow w-20 bg-gray-100">
+            <div v-if="selectedItem" class="flex flex-col border-1 border">
+                <node-panel :local="local" :incoming="incoming" :schema="selectedScheme" :selected-item="selectedItem" />
             </div>
         </div>
-        
     </div>
 
     <script src="./schemas.js"></script>  
     <script src="components/ui/collapse-extend-text.js"></script>
     <script src="components/ui/node-moving-subpanel.js"></script>
     <script src="components/ui/node-panel.js"></script>
+    <script src="components/shuffle-param.js"></script>
+    <script src="components/shuffle-params-group.js"></script>
+    <script src="components/shuffle-scheme.js"></script>
     <script src="components/shuffle-filter.js"></script>
-    <script src="components/shuffle-filter-intersection.js"></script>
     <script src="components/shuffle-column.js"></script>
     <script src="components/shuffle-row.js"></script>
+    <script src="components/shuffle-filter-intersection.js"></script>
     <script src="components/shuffle-chain.js"></script>
     <script src="libs/schemeSearch.js"></script>
     <script src="libs/schemeRunner.js"></script>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
             </div>
 
-            <div class="flex-none">
+            <div class="flex-none text-gray-400">
                 ->
             </div>
             
@@ -81,13 +81,13 @@
 
             </div>
 
-            <div class="flex-none">
+            <div class="flex-none text-gray-400">
                 ->
             </div>
 
             <!-- Result -->
             <div class="flex p-4 border">
-                1/0
+                <span class="text-gray-600">1/0</span>
             </div>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -101,8 +101,18 @@
                     <div class="flex bg-gray-200 p-2 rounded-b-lg">
                         <h2 class="text-bold">Properties</h2>
                     </div>
-                    <div class="flex flex-col p-2">
+                    <div class="flex-grow bg-white py-16 px-4">
+                        <shuffle-chain :schema="secondScheme" @focus="onFocus" @selected-item-changed="onSelectedChange" />
+                    </div>
+                </div>
+                <div class="sidebar bg-gray-100">
+                    <div v-if="selectedItem" class="flex flex-col border-1 border">
                         <div>
+                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                            <h2 class="text-bold">Properties</h2>
+                        </div>
+                        <div class="flex flex-col p-2">
+                            <div v-if="selectedItem.id">
                             id: {{ selectedItem.id }}
                         </div>
                         <div v-if="selectedItem.type=='filter-intersection'">
@@ -110,6 +120,10 @@
                         </div>
                         <div v-else>
                             type: {{ selectedItem.type }}
+                            </div>
+                            <div v-if="selectedItem.result != null" class="text-gray-400">
+                            result: {{ selectedItem.result }}
+                            </div>
                         </div>
                         <div v-if="selectedItem.result!=null" class="text-gray-400">
                             mock-result: {{selectedItem.result}}
@@ -172,8 +186,20 @@
                     </div>
                     <div class="flex flex-col p-2">
                         <div>
-                            getSchemeResult: {{getSchemeResult(selectedItem)}}
+                        <div class="flex bg-gray-200 p-2 rounded-b-lg">
+                            <h2 class="text-bold">
+                            Result
+                            </h2>
                         </div>
+                        <div class="flex flex-col p-2">
+                            <div>
+                            getSchemeResult: {{ getSchemeResult(selectedItem) }}
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                    <div v-else class="p-4">
+                        {{ message }}
                     </div>
                 </div>
             </div>

--- a/libs/schemeRunner.js
+++ b/libs/schemeRunner.js
@@ -1,26 +1,54 @@
-function runFilter(scheme) {
-    return "string" == typeof scheme.result ? "true" === scheme.result : scheme.result;
+function getParamValue(param, local, incoming) {
+    switch (param.source) {
+        case 'inline':
+            return param.value;
+        case 'local':
+            return local[param.key];
+        case 'incoming':
+            return incoming[param.key];
+        default:
+            return [];
+    }
 }
 
-function runRow(scheme) {
+function runFilterIntersection(scheme, local, incoming) {
+    let first = getParamValue(scheme.params[0], local, incoming);
+    let second = getParamValue(scheme.params[1], local, incoming);
+
+    let common = first.filter(x => second.indexOf(x) !== -1);
+
+    return common.length > 0;
+}
+
+function runFilter(scheme, local, incoming) {
+    return scheme.result === "string" && scheme.result === "true" ? true : scheme.result;
+}
+
+function runRow(scheme, local, incoming) {
     for (let child of scheme.childs) {
-        if (!runScheme(child)) return false
+        if (!runScheme(child, local, incoming)) return false;
     }
     return true;
 }
 
-function runColumn(scheme) {
+function runColumn(scheme, local, incoming) {
     for (let child of scheme.childs) {
-        if (runScheme(child)) return true
+        if (runScheme(child, local, incoming)) return true;
     }
     return false;
 }
 
-function runScheme(scheme) {
+function runScheme(scheme, local, incoming) {
     switch (scheme.type) {
-        case 'shuffle-filter': return runFilter(scheme);
-        case 'shuffle-row': return runRow(scheme);
-        case 'shuffle-column': return runColumn(scheme);
-        default: return false;
+        case 'shuffle-filter':
+            return runFilter(scheme, local, incoming);
+        case 'shuffle-filter-intersection':
+            return runFilterIntersection(scheme, local, incoming);
+        case 'shuffle-row':
+            return runRow(scheme, local, incoming);
+        case 'shuffle-column':
+            return runColumn(scheme, local, incoming);
+        default:
+            return false;
     }
 }

--- a/libs/schemeRunner.js
+++ b/libs/schemeRunner.js
@@ -3,24 +3,24 @@ function runFilter(scheme) {
 }
 
 function runRow(scheme) {
-    for(let child of scheme.childs) {
-        if(!runScheme(child))return false
+    for (let child of scheme.childs) {
+        if (!runScheme(child)) return false
     }
     return true;
 }
 
 function runColumn(scheme) {
-    for(let child of scheme.childs) {
-        if(runScheme(child))return true
+    for (let child of scheme.childs) {
+        if (runScheme(child)) return true
     }
     return false;
 }
 
 function runScheme(scheme) {
-    switch(scheme.type) {
-        case 'filter': return runFilter(scheme);
-        case 'row': return runRow(scheme);
-        case 'column': return runColumn(scheme);
+    switch (scheme.type) {
+        case 'shuffle-filter': return runFilter(scheme);
+        case 'shuffle-row': return runRow(scheme);
+        case 'shuffle-column': return runColumn(scheme);
         default: return false;
     }
 }

--- a/libs/schemeRunner.js
+++ b/libs/schemeRunner.js
@@ -1,5 +1,5 @@
 function runFilter(scheme) {
-    return scheme.result;
+    return "string" == typeof scheme.result ? "true" === scheme.result : scheme.result;
 }
 
 function runRow(scheme) {

--- a/libs/schemeRunner.js
+++ b/libs/schemeRunner.js
@@ -14,14 +14,13 @@ function getParamValue(param, local, incoming) {
 function runFilterIntersection(scheme, local, incoming) {
     let first = getParamValue(scheme.params[0], local, incoming);
     let second = getParamValue(scheme.params[1], local, incoming);
-
-    let common = first.filter(x => second.indexOf(x) !== -1);
-
+    let common = Array.isArray(first) && Array.isArray(second) ? first.filter(x => second.indexOf(x) !== -1) : [];
     return common.length > 0;
 }
 
 function runFilter(scheme, local, incoming) {
-    return scheme.result === "string" && scheme.result === "true" ? true : scheme.result;
+    const result = "string" === typeof scheme.result ? scheme.result === "true" : !!scheme.result;
+    return result;
 }
 
 function runRow(scheme, local, incoming) {

--- a/libs/schemeSearch.js
+++ b/libs/schemeSearch.js
@@ -1,13 +1,35 @@
-function searchInSchemeById(element, matchingId){
-    if(element.id == matchingId){
-         return element;
-    }else if (element.childs != null){
-         var i;
-         var result = null;
-         for(i=0; result == null && i < element.childs.length; i++){
-              result = searchInSchemeById(element.childs[i], matchingId);
-         }
-         return result;
+function searchInSchemeById(element, matchingId) {
+    if (element.id == matchingId) {
+        return element;
+    } else if (element.childs != null) {
+        var i;
+        var result = null;
+        for (i = 0; result == null && i < element.childs.length; i++) {
+            result = searchInSchemeById(element.childs[i], matchingId);
+        }
+        return result;
     }
     return null;
 }
+
+function findParentShuffleElement(tree, matchingId) {
+    if (tree.id === matchingId) {
+        return null; // Найден элемент с заданным ID, но мы ищем родительский элемент
+    }
+
+    if (tree.childs) {
+        for (const child of tree.childs) {
+            if (child.id === matchingId) {
+                return tree; // Найден родительский элемент с заданным ID
+            }
+
+            const parentElement = findParentShuffleElement(child, matchingId);
+            if (parentElement) {
+                return parentElement; // Найден родительский элемент в дочернем элементе
+            }
+        }
+    }
+
+    return null; // Родительский элемент не найден
+}
+

--- a/schemas.js
+++ b/schemas.js
@@ -140,10 +140,91 @@ var SecondChain = {
     ],
 };
 
+function generateChain(numChildren, maxDepth, isLastFilter = true) {
+    var chain = {
+        id: 'Chain',
+        type: 'shuffle-row',
+        childs: [],
+    };
+
+    function getRandomType() {
+        var types = ['shuffle-column', 'shuffle-row', 'shuffle-filter'];
+        var randomIndex = Math.floor(Math.random() * types.length);
+        return types[randomIndex];
+    }
+
+    function generateRandomChild(depth) {
+        if (depth >= maxDepth) {
+            // Если достигли максимальной глубины, то самый вложенный элемент обязан быть shuffle-filter
+            return {
+                id: Math.random().toString(36).substr(2, 4),
+                type: 'shuffle-filter',
+                result: false,
+            };
+        }
+
+        var type = getRandomType();
+
+        if (type === 'shuffle-filter' && isLastFilter) {
+            // Если это самый вложенный элемент и должен быть shuffle-filter
+            return {
+                id: Math.random().toString(36).substr(2, 4),
+                type: 'shuffle-filter',
+                result: false,
+            };
+        }
+
+        if (type === 'shuffle-filter') {
+            // Если не самый вложенный элемент, то пропускаем shuffle-filter
+            var parentTypes = ['shuffle-row', 'shuffle-column'];
+            type = parentTypes[Math.floor(Math.random() * parentTypes.length)];
+        }
+
+        if (type === 'shuffle-row' || type === 'shuffle-column') {
+            var numFilters = Math.floor(Math.random() * 2) + 2; // Генерируем случайное число от 2 до 3 для количества shuffle-filter
+            var childs = [];
+            for (var i = 0; i < numFilters; i++) {
+                childs.push({
+                    id: Math.random().toString(36).substr(2, 4),
+                    type: 'shuffle-filter',
+                    result: false,
+                });
+            }
+            // Если тип элемента shuffle-row или shuffle-column, устанавливаем isLastFilter в false
+            return {
+                id: Math.random().toString(36).substr(2, 4),
+                type: type,
+                childs: childs.concat(generateRandomChild(depth + 1)), // Добавляем рекурсивно сгенерированные дочерние элементы
+            };
+        }
+
+        return {
+            id: Math.random().toString(36).substr(2, 4),
+            type: type,
+            childs: [],
+        };
+    }
+
+    // Генерируем корневой элемент и его дочерние элементы
+    var numChilds = Math.floor(Math.random() * numChildren) + 1;
+    for (var i = 0; i < numChilds; i++) {
+        chain.childs.push(generateRandomChild(1));
+    }
+
+    return chain;
+}
+
 // Export are variables to the window
 if (typeof window !== 'undefined') {
-    window.MainChain = MainChain;
-    window.SecondChain = SecondChain;
+    window.chains = [];
+    window.chains.push({ name: 'MainChain', value: MainChain });
+    window.chains.push({ name: 'SecondChain', value: SecondChain });
+    window.chains.push({ name: '5 elements with depth 5 random', value: generateChain(5, 5) });
+    window.chains.push({ name: '10 elements with depth 5 random', value: generateChain(10, 5) });
+    window.chains.push({ name: '32 elements with depth 10 random', value: generateChain(32, 10) });
+    window.chains.push({ name: '64 elements with depth 12 random', value: generateChain(64, 12) });
+    window.chains.push({ name: '128 elements with depth 28 random', value: generateChain(128, 28) });
+
     // Export other schemas as needed
     // window.Schema2 = Schema2;
     // window.Schema3 = Schema3;

--- a/schemas.js
+++ b/schemas.js
@@ -12,13 +12,39 @@ var MainChain = {
                     childs: [
                         {
                             id: 'A1',
-                            type: 'shuffle-filter',
-                            result: false,
+                            type: 'shuffle-filter-intersection',
+                            params: [
+                                {
+                                    name: 'Alpha',
+                                    type: 'set',
+                                    source: 'inline',
+                                    value: ['cafe', 'kids', 'beach'],
+                                },
+                                {
+                                    name: 'Beta',
+                                    type: 'set',
+                                    source: 'local',
+                                    key: "ballooning-fest",
+                                }
+                            ]
                         },
                         {
                             id: 'A2',
-                            type: 'shuffle-filter',
-                            result: true,
+                            type: 'shuffle-filter-intersection',
+                            params: [
+                                {
+                                    name: 'User',
+                                    type: 'set',
+                                    source: 'incoming',
+                                    key: 'user',
+                                },
+                                {
+                                    name: 'Cafe',
+                                    type: 'set',
+                                    source: 'incoming',
+                                    key: 'place',
+                                }
+                            ]
                         },
                     ],
                 },
@@ -56,11 +82,6 @@ var MainChain = {
                 },
                 {
                     id: 'Z2',
-                    type: 'shuffle-filter',
-                    result: true,
-                },
-                {
-                    id: 'Z3',
                     type: 'shuffle-filter',
                     result: true,
                 },

--- a/schemas.js
+++ b/schemas.js
@@ -1,0 +1,150 @@
+var MainChain = {
+    id: 'Main',
+    type: 'shuffle-row',
+    childs: [
+        {
+            id: 'D',
+            type: 'shuffle-column',
+            childs: [
+                {
+                    id: 'A',
+                    type: 'shuffle-row',
+                    childs: [
+                        {
+                            id: 'A1',
+                            type: 'shuffle-filter',
+                            result: false,
+                        },
+                        {
+                            id: 'A2',
+                            type: 'shuffle-filter',
+                            result: true,
+                        },
+                    ],
+                },
+                {
+                    id: 'B',
+                    type: 'shuffle-column',
+                    childs: [
+                        {
+                            id: 'B1',
+                            type: 'shuffle-filter',
+                            result: true,
+                        },
+                        {
+                            id: 'B2',
+                            type: 'shuffle-filter',
+                            result: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            id: 'C1',
+            type: 'shuffle-filter',
+            result: true,
+        },
+        {
+            id: 'Z',
+            type: 'shuffle-column',
+            childs: [
+                {
+                    id: 'Z1',
+                    type: 'shuffle-filter',
+                    result: false,
+                },
+                {
+                    id: 'Z2',
+                    type: 'shuffle-filter',
+                    result: true,
+                },
+                {
+                    id: 'Z3',
+                    type: 'shuffle-filter',
+                    result: true,
+                },
+            ],
+        },
+    ],
+};
+
+var SecondChain = {
+    id: 'SecondChain',
+    type: 'shuffle-row',
+    childs: [
+        {
+            id: 'K',
+            type: 'shuffle-column',
+            childs: [
+                {
+                    id: 'M',
+                    type: 'shuffle-row',
+                    childs: [
+                        {
+                            id: 'M1',
+                            type: 'shuffle-filter',
+                            result: false,
+                        },
+                    ],
+                },
+                {
+                    id: 'X',
+                    type: 'shuffle-column',
+                    childs: [
+                        {
+                            id: 'X1',
+                            type: 'shuffle-filter',
+                            result: false,
+                        },
+                        {
+                            id: 'X2',
+                            type: 'shuffle-filter',
+                            result: true,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            id: 'G1',
+            type: 'shuffle-filter',
+            result: true,
+        },
+        {
+            id: 'G2',
+            type: 'shuffle-filter',
+            result: true,
+        },
+        {
+            id: 'F',
+            type: 'shuffle-column',
+            childs: [
+                {
+                    id: 'F1',
+                    type: 'shuffle-filter',
+                    result: false,
+                },
+                {
+                    id: 'F2',
+                    type: 'shuffle-filter',
+                    result: true,
+                },
+                {
+                    id: 'F3',
+                    type: 'shuffle-filter',
+                    result: true,
+                },
+            ],
+        },
+    ],
+};
+
+// Export are variables to the window
+if (typeof window !== 'undefined') {
+    window.MainChain = MainChain;
+    window.SecondChain = SecondChain;
+    // Export other schemas as needed
+    // window.Schema2 = Schema2;
+    // window.Schema3 = Schema3;
+}


### PR DESCRIPTION
This commit introduces a new component called 'shuffle-chain'. The 'shuffle-chain' component is used to render a chain of components based on the provided schema. It accepts the 'schema' prop, which should be an object representing the component chain. The 'shuffle-chain' component recursively renders its children components according to the given schema. It also emits the 'selected-item-changed' event whenever an item in the chain is selected, allowing the parent component to keep track of the selected item.

The 'shuffle-chain' component is now part of the project and can be used to create complex component structures based on nested schemas.